### PR TITLE
chore: DBエンティティ・シードスクリプトの作成 (#15)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node -r tsconfig-paths/register src/database/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/backend/src/admin-user/admin-user.entity.ts
+++ b/backend/src/admin-user/admin-user.entity.ts
@@ -1,0 +1,25 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('admin_user')
+export class AdminUser {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  email: string;
+
+  @Column({ type: 'varchar', length: 255, name: 'password_hash' })
+  passwordHash: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/seed.ts
+++ b/backend/src/database/seed.ts
@@ -1,0 +1,37 @@
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { AdminUser } from '../admin-user/admin-user.entity';
+import { Inquiry } from '../inquiry/inquiry.entity';
+
+const dataSource = new DataSource({
+  type: 'mysql',
+  host: process.env.DB_HOST ?? 'localhost',
+  port: parseInt(process.env.DB_PORT ?? '3306', 10),
+  username: process.env.DB_USERNAME ?? 'app',
+  password: process.env.DB_PASSWORD ?? 'password',
+  database: process.env.DB_DATABASE ?? 'inquiry_management',
+  entities: [AdminUser, Inquiry],
+  synchronize: false,
+});
+
+async function seed() {
+  await dataSource.initialize();
+
+  const adminRepo = dataSource.getRepository(AdminUser);
+
+  const exists = await adminRepo.findOneBy({ email: 'admin@example.com' });
+  if (!exists) {
+    const passwordHash = await bcrypt.hash('password123', 10);
+    await adminRepo.save({ email: 'admin@example.com', passwordHash });
+    console.log('Seeded: admin@example.com');
+  } else {
+    console.log('Skipped: admin@example.com already exists');
+  }
+
+  await dataSource.destroy();
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/inquiry/inquiry.entity.ts
+++ b/backend/src/inquiry/inquiry.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum InquiryStatus {
+  OPEN = 'open',
+  IN_PROGRESS = 'in_progress',
+  CLOSED = 'closed',
+}
+
+@Entity('inquiry')
+export class Inquiry {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  email: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  subject: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({
+    type: 'enum',
+    enum: InquiryStatus,
+    default: InquiryStatus.OPEN,
+  })
+  status: InquiryStatus;
+
+  @Column({ type: 'datetime', name: 'received_at', default: () => 'CURRENT_TIMESTAMP' })
+  receivedAt: Date;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}


### PR DESCRIPTION
## 概要

ステップ2として、TypeORM エンティティと初期データのシードスクリプトを整備します。

## 変更内容

- `backend/src/admin-user/admin-user.entity.ts` — AdminUser エンティティ（`admin_user` テーブル）
- `backend/src/inquiry/inquiry.entity.ts` — Inquiry エンティティ（`inquiry` テーブル・`InquiryStatus` enum）
- `backend/src/database/seed.ts` — 初期管理者シードスクリプト（bcrypt ハッシュ済み）
- `backend/package.json` — `npm run seed` コマンドを追加

## シードアカウント

| 項目 | 値 |
|------|----|
| email | admin@example.com |
| password | password123 |

## 動作確認

- [x] `npm run start:dev` 起動 → `admin_user`・`inquiry` テーブルが自動生成されることを確認
- [x] `npm run seed` 実行 → `admin@example.com` が bcrypt ハッシュ済みで登録されることを確認
- [x] MySQL で `SELECT * FROM admin_user` → レコード1件を確認

Closes #15