### PR TITLE
feat: 管理者ログイン・ログアウトAPIを実装 (#17)

### DIFF
--- a/backend/src/admin-user/admin-user.module.ts
+++ b/backend/src/admin-user/admin-user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminUser } from './admin-user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AdminUser])],
+  exports: [TypeOrmModule],
+})
+export class AdminUserModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AppService } from './app.service';
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: process.env.NODE_ENV !== 'production',
     }),
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Res,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+import { AuthService } from './auth.service';
+
+class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(8)
+  password: string;
+}
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(
+    @Body() dto: LoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const token = await this.authService.login(dto.email, dto.password);
+
+    res.cookie('access_token', token, {
+      httpOnly: true,
+      sameSite: 'strict',
+      maxAge: 8 * 60 * 60 * 1000,
+    });
+
+    return { message: 'ログインしました' };
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  logout(@Res({ passthrough: true }) res: Response) {
+    res.clearCookie('access_token');
+    return { message: 'ログアウトしました' };
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AdminUserModule } from '../admin-user/admin-user.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    AdminUserModule,
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET ?? 'change_me_in_production',
+      signOptions: { expiresIn: '8h' },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard],
+  exports: [JwtAuthGuard],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { AdminUser } from '../admin-user/admin-user.entity';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(AdminUser)
+    private readonly adminUserRepository: Repository<AdminUser>,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async login(email: string, password: string): Promise<string> {
+    const user = await this.adminUserRepository.findOneBy({ email });
+
+    if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
+      throw new UnauthorizedException('メールアドレスまたはパスワードが正しくありません');
+    }
+
+    return this.jwtService.sign({ sub: user.id });
+  }
+}

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,0 +1,28 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Request } from 'express';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Repository } from 'typeorm';
+import { AdminUser } from '../admin-user/admin-user.entity';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    @InjectRepository(AdminUser)
+    private readonly adminUserRepository: Repository<AdminUser>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => req?.cookies?.access_token ?? null,
+      ]),
+      secretOrKey: process.env.JWT_SECRET ?? 'change_me_in_production',
+    });
+  }
+
+  async validate(payload: { sub: number }): Promise<AdminUser> {
+    const user = await this.adminUserRepository.findOneBy({ id: payload.sub });
+    if (!user) throw new UnauthorizedException();
+    return user;
+  }
+}


### PR DESCRIPTION
## 概要

F-03「管理者ログイン／ログアウト」のバックエンドAPIを実装します。

## 変更内容

- `admin-user/admin-user.module.ts` — AdminUserModule を追加
- `auth/auth.service.ts` — bcrypt でパスワード照合・JWT 発行
- `auth/auth.controller.ts` — ログイン・ログアウトエンドポイント
- `auth/jwt.strategy.ts` — Cookie からトークンを取り出して検証
- `auth/jwt-auth.guard.ts` — 認証保護用ガード
- `auth/auth.module.ts` — AuthModule
- `app.module.ts` — AuthModule を登録

## エンドポイント

| メソッド | パス | 説明 |
|---------|------|------|
| POST | /auth/login | ログイン（HttpOnly Cookie に JWT をセット） |
| POST | /auth/logout | ログアウト（Cookie を破棄） |

## 動作確認

- [x] `POST /auth/login`（正しい認証情報）→ `{"message":"ログインしました"}` + `access_token` Cookie がセットされることを確認
- [x] `POST /auth/login`（誤ったパスワード）→ 401 + `メールアドレスまたはパスワードが正しくありません` を確認
- [x] `POST /auth/logout` → Cookie が削除されることを確認

Closes #17