### PR TITLE
feat: 問い合わせ管理APIを実装 (#19)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { InquiryModule } from './inquiry/inquiry.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AuthModule } from './auth/auth.module';
       synchronize: process.env.NODE_ENV !== 'production',
     }),
     AuthModule,
+    InquiryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/inquiry/inquiry.controller.ts
+++ b/backend/src/inquiry/inquiry.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
+import { IsEnum } from 'class-validator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { InquiryStatus } from './inquiry.entity';
+import { InquiryService } from './inquiry.service';
+
+class UpdateStatusDto {
+  @IsEnum(InquiryStatus)
+  status: InquiryStatus;
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('inquiries')
+export class InquiryController {
+  constructor(private readonly inquiryService: InquiryService) {}
+
+  @Get()
+  findAll() {
+    return this.inquiryService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.inquiryService.findOne(id);
+  }
+
+  @Patch(':id/status')
+  updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateStatusDto,
+  ) {
+    return this.inquiryService.updateStatus(id, dto.status);
+  }
+}

--- a/backend/src/inquiry/inquiry.module.ts
+++ b/backend/src/inquiry/inquiry.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { InquiryController } from './inquiry.controller';
+import { Inquiry } from './inquiry.entity';
+import { InquiryService } from './inquiry.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Inquiry]), AuthModule],
+  controllers: [InquiryController],
+  providers: [InquiryService],
+})
+export class InquiryModule {}

--- a/backend/src/inquiry/inquiry.service.ts
+++ b/backend/src/inquiry/inquiry.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Inquiry, InquiryStatus } from './inquiry.entity';
+
+@Injectable()
+export class InquiryService {
+  constructor(
+    @InjectRepository(Inquiry)
+    private readonly inquiryRepository: Repository<Inquiry>,
+  ) {}
+
+  findAll(): Promise<Inquiry[]> {
+    return this.inquiryRepository.find({ order: { receivedAt: 'DESC' } });
+  }
+
+  async findOne(id: number): Promise<Inquiry> {
+    const inquiry = await this.inquiryRepository.findOneBy({ id });
+    if (!inquiry) {
+      throw new NotFoundException(`Inquiry #${id} not found`);
+    }
+    return inquiry;
+  }
+
+  async updateStatus(id: number, status: InquiryStatus): Promise<Inquiry> {
+    const inquiry = await this.findOne(id);
+    inquiry.status = status;
+    return this.inquiryRepository.save(inquiry);
+  }
+}


### PR DESCRIPTION
## 概要
問い合わせ管理APIを実装しました。

## 変更内容
- `InquiryService` — 一覧取得・詳細取得・ステータス更新ロジック
- `InquiryController` — 各エンドポイントの定義、`JwtAuthGuard` による認証保護
- `InquiryModule` — モジュール定義
- `AppModule` — `InquiryModule` を登録

## エンドポイント
| メソッド | パス | 説明 |
|---|---|---|
| GET | `/inquiries` | 一覧取得（JWT認証必須） |
| GET | `/inquiries/:id` | 詳細取得（JWT認証必須） |
| PATCH | `/inquiries/:id/status` | ステータス更新（JWT認証必須） |

Closes #19