### PR TITLE
feat: 問い合わせ送信APIを追加 (#21)

### DIFF
--- a/backend/src/inquiry/inquiry.controller.ts
+++ b/backend/src/inquiry/inquiry.controller.ts
@@ -2,36 +2,47 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Patch,
+  Post,
   UseGuards,
 } from '@nestjs/common';
 import { IsEnum } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { InquiryStatus } from './inquiry.entity';
-import { InquiryService } from './inquiry.service';
+import { CreateInquiryDto, InquiryService } from './inquiry.service';
 
 class UpdateStatusDto {
   @IsEnum(InquiryStatus)
   status: InquiryStatus;
 }
 
-@UseGuards(JwtAuthGuard)
 @Controller('inquiries')
 export class InquiryController {
   constructor(private readonly inquiryService: InquiryService) {}
 
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateInquiryDto) {
+    return this.inquiryService.create(dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get()
   findAll() {
     return this.inquiryService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.inquiryService.findOne(id);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch(':id/status')
   updateStatus(
     @Param('id', ParseIntPipe) id: number,

--- a/backend/src/inquiry/inquiry.service.ts
+++ b/backend/src/inquiry/inquiry.service.ts
@@ -1,7 +1,27 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
 import { Repository } from 'typeorm';
 import { Inquiry, InquiryStatus } from './inquiry.entity';
+
+export class CreateInquiryDto {
+  @IsString()
+  @MaxLength(255)
+  name: string;
+
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  subject: string;
+
+  @IsString()
+  @MinLength(1)
+  body: string;
+}
 
 @Injectable()
 export class InquiryService {
@@ -9,6 +29,11 @@ export class InquiryService {
     @InjectRepository(Inquiry)
     private readonly inquiryRepository: Repository<Inquiry>,
   ) {}
+
+  create(dto: CreateInquiryDto): Promise<Inquiry> {
+    const inquiry = this.inquiryRepository.create(dto);
+    return this.inquiryRepository.save(inquiry);
+  }
 
   findAll(): Promise<Inquiry[]> {
     return this.inquiryRepository.find({ order: { receivedAt: 'DESC' } });


### PR DESCRIPTION
## 概要
一般ユーザーが問い合わせを送信する `POST /inquiries` エンドポイントを追加しました。

## 変更内容
- `CreateInquiryDto` を追加（name, email, subject, body のバリデーション）
- `InquiryService` に `create` メソッドを追加
- `InquiryController` に `POST /inquiries` を追加（認証不要）
- 既存の GET / PATCH エンドポイントの `@UseGuards` をメソッドレベルに移動

## エンドポイント一覧（全量）
| メソッド | パス | 認証 | 説明 |
|---|---|---|---|
| POST | `/inquiries` | 不要 | 問い合わせ送信 |
| GET | `/inquiries` | 必要 | 一覧取得 |
| GET | `/inquiries/:id` | 必要 | 詳細取得 |
| PATCH | `/inquiries/:id/status` | 必要 | ステータス更新 |

Closes #21