### PR TITLE
feat: 管理者ログイン画面を実装 (#23)

### DIFF
--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -48,7 +48,7 @@ export default function AdminLoginPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
-        <h1 className="text-2xl font-bold text-center mb-8">管理者ログイン</h1>
+        <h1 className="text-2xl font-bold text-center text-gray-900 mb-8">管理者ログイン</h1>
 
         {error && (
           <p className="mb-4 text-sm text-red-600 bg-red-50 border border-red-200 rounded px-4 py-3">
@@ -58,7 +58,7 @@ export default function AdminLoginPage() {
 
         <form onSubmit={handleSubmit} noValidate>
           <div className="mb-5">
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-900 mb-1">
               メールアドレス
             </label>
             <input
@@ -66,12 +66,12 @@ export default function AdminLoginPage() {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
           <div className="mb-7">
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-900 mb-1">
               パスワード
             </label>
             <input
@@ -79,7 +79,7 @@ export default function AdminLoginPage() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 

--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+
+    if (!email) {
+      setError('メールアドレスを入力してください');
+      return;
+    }
+    if (!password) {
+      setError('パスワードを入力してください');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch('http://localhost:3001/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        setError('メールアドレスまたはパスワードが正しくありません');
+        return;
+      }
+
+      router.push('/admin/inquiries');
+    } catch {
+      setError('通信エラーが発生しました。しばらく経ってから再試行してください');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
+        <h1 className="text-2xl font-bold text-center mb-8">管理者ログイン</h1>
+
+        {error && (
+          <p className="mb-4 text-sm text-red-600 bg-red-50 border border-red-200 rounded px-4 py-3">
+            {error}
+          </p>
+        )}
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="mb-5">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="mb-7">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 text-white py-2 rounded text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? 'ログイン中...' : 'ログイン'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
S-03 管理者ログイン画面を実装しました。

## 変更内容
- `app/admin/login/page.tsx` — ログインフォーム（クライアントコンポーネント）

## 動作
- ログイン成功 → `/admin/inquiries` へリダイレクト
- 認証失敗 → エラーメッセージ表示
- 必須未入力 → フィールドごとのエラーメッセージ表示

## 技術的な判断
バックエンドがCORS + `credentials: true` を設定済みのため、ブラウザから直接バックエンドへ `credentials: 'include'` で通信し、HttpOnly クッキーをバックエンドが直接セットする方式を採用。

Closes #23