### PR TITLE
feat: 問い合わせ送信フォームと完了画面を実装 (#29)

### DIFF
--- a/frontend/app/complete/page.tsx
+++ b/frontend/app/complete/page.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+
+interface Props {
+  searchParams: Promise<{ id?: string }>;
+}
+
+export default async function CompletePage({ searchParams }: Props) {
+  const { id } = await searchParams;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-lg mx-auto bg-white rounded-lg shadow p-8 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">お問い合わせ</h1>
+
+        <div className="mb-6">
+          <span className="text-4xl">✓</span>
+          <p className="text-lg font-medium text-gray-900 mt-3">送信が完了しました</p>
+        </div>
+
+        <p className="text-sm text-gray-700 mb-2">お問い合わせを受け付けました。</p>
+        <p className="text-sm text-gray-700 mb-6">内容を確認のうえ、担当者よりご連絡いたします。</p>
+
+        {id && (
+          <p className="text-sm text-gray-600 mb-8">
+            受付番号: <span className="font-medium text-gray-900">{id}</span>
+          </p>
+        )}
+
+        <Link
+          href="/"
+          className="inline-block bg-blue-600 text-white text-sm font-medium px-6 py-2 rounded hover:bg-blue-700 transition-colors"
+        >
+          新しいお問い合わせを送る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,65 +1,157 @@
-import Image from "next/image";
+'use client';
 
-export default function Home() {
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+interface FormValues {
+  name: string;
+  email: string;
+  subject: string;
+  body: string;
+  website: string; // honeypot
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  subject?: string;
+  body?: string;
+}
+
+function validate(values: FormValues): FormErrors {
+  const errors: FormErrors = {};
+  if (!values.name.trim()) errors.name = 'お名前を入力してください';
+  else if (values.name.trim().length > 255) errors.name = '255文字以内で入力してください';
+
+  if (!values.email.trim()) errors.email = 'メールアドレスを入力してください';
+  else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) errors.email = '正しいメールアドレスを入力してください';
+  else if (values.email.length > 255) errors.email = '255文字以内で入力してください';
+
+  if (!values.subject.trim()) errors.subject = '件名を入力してください';
+  else if (values.subject.trim().length > 100) errors.subject = '100文字以内で入力してください';
+
+  if (!values.body.trim()) errors.body = 'お問い合わせ内容を入力してください';
+  else if (values.body.trim().length > 2000) errors.body = '2000文字以内で入力してください';
+
+  return errors;
+}
+
+export default function InquiryFormPage() {
+  const router = useRouter();
+  const [values, setValues] = useState<FormValues>({ name: '', email: '', subject: '', body: '', website: '' });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [serverError, setServerError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    setValues((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+    setErrors((prev) => ({ ...prev, [e.target.name]: undefined }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setServerError('');
+
+    if (values.website) return;
+
+    const validationErrors = validate(values);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await fetch('http://localhost:3001/inquiries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: values.name.trim(),
+          email: values.email.trim(),
+          subject: values.subject.trim(),
+          body: values.body.trim(),
+        }),
+      });
+
+      if (res.status === 429) {
+        setServerError('送信回数の制限に達しました。しばらくお待ちください');
+        return;
+      }
+      if (!res.ok) {
+        setServerError('送信に失敗しました。時間をおいて再度お試しください');
+        return;
+      }
+
+      const data = await res.json();
+      router.push(`/complete?id=${data.id}`);
+    } catch {
+      setServerError('送信に失敗しました。時間をおいて再度お試しください');
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+    <div className="min-h-screen bg-gray-50 py-12 px-4">
+      <div className="max-w-lg mx-auto bg-white rounded-lg shadow p-8">
+        <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">お問い合わせ</h1>
+
+        {serverError && (
+          <p className="mb-6 text-sm text-red-600 bg-red-50 border border-red-200 rounded px-4 py-3">
+            {serverError}
           </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
+        )}
+
+        <form onSubmit={handleSubmit} noValidate>
+          <input type="text" name="website" value={values.website} onChange={handleChange} className="hidden" tabIndex={-1} autoComplete="off" />
+
+          {[
+            { name: 'name', label: 'お名前', type: 'text', required: true },
+            { name: 'email', label: 'メールアドレス', type: 'email', required: true },
+            { name: 'subject', label: '件名', type: 'text', required: true },
+          ].map(({ name, label, type, required }) => (
+            <div key={name} className="mb-5">
+              <label htmlFor={name} className="block text-sm font-medium text-gray-900 mb-1">
+                {label} {required && <span className="text-red-500">*</span>}
+              </label>
+              <input
+                id={name}
+                name={name}
+                type={type}
+                value={values[name as keyof FormValues]}
+                onChange={handleChange}
+                className={`w-full border rounded px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${errors[name as keyof FormErrors] ? 'border-red-400' : 'border-gray-300'}`}
+              />
+              {errors[name as keyof FormErrors] && (
+                <p className="mt-1 text-xs text-red-600">{errors[name as keyof FormErrors]}</p>
+              )}
+            </div>
+          ))}
+
+          <div className="mb-7">
+            <label htmlFor="body" className="block text-sm font-medium text-gray-900 mb-1">
+              お問い合わせ内容 <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              id="body"
+              name="body"
+              rows={5}
+              value={values.body}
+              onChange={handleChange}
+              className={`w-full border rounded px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y ${errors.body ? 'border-red-400' : 'border-gray-300'}`}
             />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+            {errors.body && <p className="mt-1 text-xs text-red-600">{errors.body}</p>}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 text-white py-2 rounded text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            Documentation
-          </a>
-        </div>
-      </main>
+            {loading ? '送信中...' : '送信する'}
+          </button>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
S-01 問い合わせ送信フォームと S-02 送信完了画面を実装しました。

## 変更内容
- `app/page.tsx` — 問い合わせ送信フォーム
  - フィールドごとのバリデーション（必須・文字数・メール形式）
  - honeypot フィールドによるスパム対策
  - 送信成功時 `/complete?id=<受付番号>` へリダイレクト
- `app/complete/page.tsx` — 送信完了画面
  - 受付番号を表示（URLパラメータから取得）
  - フォームへ戻るリンク
  - 直接アクセス時は受付番号を非表示

Closes #29