### PR TITLE
feat: Terraform で AWS インフラを構築する (#31)

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,71 @@
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                    = data.aws_ami.amazon_linux_2023.id
+  instance_type          = "t3.micro"
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.app.id]
+  key_name               = var.key_pair_name
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    dnf update -y
+    curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
+    dnf install -y nodejs git nginx
+    npm install -g pm2
+
+    # Nginx リバースプロキシ設定
+    cat > /etc/nginx/conf.d/inquiry.conf <<'NGINX'
+    server {
+        listen 80;
+        server_name _;
+
+        location /api {
+            proxy_pass http://localhost:3001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location / {
+            proxy_pass http://localhost:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+    NGINX
+
+    systemctl enable nginx
+    systemctl start nginx
+  EOF
+
+  tags = {
+    Name = "${var.project_name}-ec2"
+  }
+}
+
+resource "aws_eip" "app" {
+  instance = aws_instance.app.id
+  domain   = "vpc"
+
+  tags = {
+    Name = "${var.project_name}-eip"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "ec2_public_ip" {
+  description = "EC2 instance Elastic IP (use this for SSH and browser access)"
+  value       = aws_eip.app.public_ip
+}
+
+output "rds_endpoint" {
+  description = "RDS MySQL endpoint (set as DATABASE_HOST in backend .env)"
+  value       = aws_db_instance.main.address
+}
+
+output "ssh_command" {
+  description = "SSH command to connect to EC2"
+  value       = "ssh -i <your-key.pem> ec2-user@${aws_eip.app.public_ip}"
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,34 @@
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet-group"
+  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+
+  tags = {
+    Name = "${var.project_name}-db-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${var.project_name}-rds"
+  engine            = "mysql"
+  engine_version    = "8.0"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  storage_type      = "gp2"
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+
+  multi_az               = false
+  publicly_accessible    = false
+  skip_final_snapshot    = true
+  backup_retention_period = 7
+  deletion_protection    = false
+
+  tags = {
+    Name = "${var.project_name}-rds"
+  }
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,0 +1,73 @@
+resource "aws_security_group" "app" {
+  name        = "${var.project_name}-sg-app"
+  description = "Security group for EC2 app server"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP via Nginx"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Next.js"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "NestJS"
+    from_port   = 3001
+    to_port     = 3001
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-sg-app"
+  }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.project_name}-sg-db"
+  description = "Security group for RDS MySQL"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL from EC2 only"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-sg-db"
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+aws_region    = "ap-northeast-1"
+project_name  = "inquiry-management"
+key_pair_name = "your-key-pair-name"
+db_name       = "inquiry_db"
+db_username   = "admin"
+db_password   = "YourSecurePassword123"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "inquiry-management"
+}
+
+variable "key_pair_name" {
+  description = "Name of the EC2 key pair created in AWS console"
+  type        = string
+}
+
+variable "db_name" {
+  description = "MySQL database name"
+  type        = string
+  default     = "inquiry_db"
+}
+
+variable "db_username" {
+  description = "MySQL master username"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "MySQL master password (8+ characters)"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,68 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# EC2 用パブリックサブネット
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-public"
+  }
+}
+
+# RDS 用プライベートサブネット（2AZ 必要）
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "${var.aws_region}a"
+
+  tags = {
+    Name = "${var.project_name}-private-a"
+  }
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.3.0/24"
+  availability_zone = "${var.aws_region}c"
+
+  tags = {
+    Name = "${var.project_name}-private-c"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## 概要

Terraform を使って本番用 AWS インフラを最小構成で構築する。

## 作成リソース

| ファイル | リソース |
|---------|---------|
| `vpc.tf` | VPC, パブリックサブネット, プライベートサブネット×2, IGW, ルートテーブル |
| `security_groups.tf` | sg-app（EC2用）, sg-db（RDS用） |
| `ec2.tf` | EC2 t3.micro, Elastic IP, user_data（Node.js 20 / Nginx / PM2） |
| `rds.tf` | RDS MySQL 8.0 db.t3.micro, DBサブネットグループ |
| `outputs.tf` | EC2パブリックIP, RDSエンドポイント, SSHコマンド |

## 無料枠対応

- EC2: t3.micro（750時間/月）
- RDS: db.t3.micro + gp2 20GB（750時間/月）
- NAT Gateway なし（コスト削減）
- Elastic IP: インスタンス稼働中は無料

## 使い方

```bash
cd terraform
cp terraform.tfvars.example terraform.tfvars
# terraform.tfvars を編集してパスワード等を設定
terraform init
terraform plan
terraform apply
```

Closes #31