### PR TITLE
feat: 問い合わせ送信に IP レートリミットを追加 (#33)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.1",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -2456,6 +2457,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.1",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -7,6 +8,13 @@ import { InquiryModule } from './inquiry/inquiry.module';
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot([
+      {
+        name: 'inquiry-create',
+        ttl: 60_000,
+        limit: 5,
+      },
+    ]),
     TypeOrmModule.forRoot({
       type: 'mysql',
       host: process.env.DB_HOST ?? 'localhost',

--- a/backend/src/inquiry/inquiry.controller.ts
+++ b/backend/src/inquiry/inquiry.controller.ts
@@ -11,6 +11,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { IsEnum, IsOptional } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { InquiryStatus } from './inquiry.entity';
@@ -40,6 +41,8 @@ export class InquiryController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @Throttle({ 'inquiry-create': { limit: 5, ttl: 60_000 } })
+  @UseGuards(ThrottlerGuard)
   create(@Body() dto: CreateInquiryDto) {
     return this.inquiryService.create(dto);
   }


### PR DESCRIPTION
## 概要

F-01 機能要件のスパム対策を IP レートリミットで実装する。

## 変更内容

- \`@nestjs/throttler\` を導入
- \`POST /inquiries\` に 1 IP あたり 1 分間 5 回までの制限を設定
- 超過時は HTTP 429 を返す（フロントエンドは既に 429 ハンドリング済み）
- 認証API・問い合わせ管理API はレートリミット対象外

## 動作確認

\`\`\`
Request 1: HTTP 201
Request 2: HTTP 201
Request 3: HTTP 201
Request 4: HTTP 201
Request 5: HTTP 201
Request 6: HTTP 429   ← 制限発動
\`\`\`

Closes #33