### PR TITLE
chore: 課金リスクのあるリソースを削減 (#37)

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -80,7 +80,7 @@ graph TD
 | AMI | Amazon Linux 2023 |
 | ストレージ | 20 GB（gp3） |
 | 配置 | パブリックサブネット |
-| Elastic IP | 割り当てあり（固定 IP） |
+| Elastic IP | なし（学習用途のため動的 public IP を使用） |
 
 **動作するプロセス**
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -60,12 +60,3 @@ resource "aws_instance" "app" {
     Name = "${var.project_name}-ec2"
   }
 }
-
-resource "aws_eip" "app" {
-  instance = aws_instance.app.id
-  domain   = "vpc"
-
-  tags = {
-    Name = "${var.project_name}-eip"
-  }
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,6 @@
 output "ec2_public_ip" {
-  description = "EC2 instance Elastic IP (use this for SSH and browser access)"
-  value       = aws_eip.app.public_ip
+  description = "EC2 instance public IP (changes on stop/start - use for SSH and browser access)"
+  value       = aws_instance.app.public_ip
 }
 
 output "rds_endpoint" {
@@ -10,5 +10,5 @@ output "rds_endpoint" {
 
 output "ssh_command" {
   description = "SSH command to connect to EC2"
-  value       = "ssh -i <your-key.pem> ec2-user@${aws_eip.app.public_ip}"
+  value       = "ssh -i <your-key.pem> ec2-user@${aws_instance.app.public_ip}"
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "main" {
   multi_az               = false
   publicly_accessible    = false
   skip_final_snapshot    = true
-  backup_retention_period = 7
+  backup_retention_period = 0
   deletion_protection    = false
 
   tags = {


### PR DESCRIPTION
## 概要

学習用途のため、停止時等に課金が発生し得るリソースを最小化する。

## 変更内容

| 変更 | 理由 |
|------|------|
| \`aws_eip.app\` を削除 | EC2 停止時に課金が発生（稼働中なら無料だが学習用途では停止リスクあり） |
| RDS \`backup_retention_period\`: 7 → 0 | 自動バックアップ無効化、バックアップストレージ料金回避 |
| \`outputs\` を \`aws_instance.app.public_ip\` に変更 | EIP 削除に伴う参照修正 |
| \`required_version\`: >= 1.6 → >= 1.5 | 手元の Terraform 1.5.2 で動作可能に |
| インフラ設計書の整合 | EIP 記載を「なし」に更新 |

## トレードオフ

- EC2 を停止/起動するたびに public IP が変わる（再起動では維持）
- DB のバックアップが取られない（学習用途なので問題なし）

## リソース数

13 → **12**

Closes #37