### PR TITLE
fix: フロントエンドの API URL 環境変数化 + ビルドエラー修正 (#41)

### DIFF
--- a/frontend/app/admin/inquiries/[id]/page.tsx
+++ b/frontend/app/admin/inquiries/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { API_URL } from '@/lib/api';
 
 type InquiryStatus = 'open' | 'in_progress' | 'closed';
 
@@ -44,7 +45,7 @@ export default function InquiryDetailPage() {
 
   useEffect(() => {
     async function load() {
-      const res = await fetch(`http://localhost:3001/inquiries/${id}`, {
+      const res = await fetch(`${API_URL}/inquiries/${id}`, {
         credentials: 'include',
       });
       if (res.status === 401) {
@@ -67,7 +68,7 @@ export default function InquiryDetailPage() {
     setSaveError('');
     setSaved(false);
     try {
-      const res = await fetch(`http://localhost:3001/inquiries/${id}/status`, {
+      const res = await fetch(`${API_URL}/inquiries/${id}/status`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -114,7 +115,7 @@ export default function InquiryDetailPage() {
         <h1 className="text-lg font-bold text-gray-900">問い合わせ管理システム</h1>
         <button
           onClick={async () => {
-            await fetch('http://localhost:3001/auth/logout', { method: 'POST', credentials: 'include' });
+            await fetch(`${API_URL}/auth/logout`, { method: 'POST', credentials: 'include' });
             router.push('/admin/login');
           }}
           className="text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded px-3 py-1"

--- a/frontend/app/admin/inquiries/page.tsx
+++ b/frontend/app/admin/inquiries/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { API_URL } from '@/lib/api';
 
 type InquiryStatus = 'open' | 'in_progress' | 'closed';
 
@@ -42,7 +43,7 @@ function formatDate(iso: string): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
-export default function InquiryListPage() {
+function InquiryListContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -77,7 +78,7 @@ export default function InquiryListPage() {
         const params = new URLSearchParams({ sort, page: String(page) });
         if (status) params.set('status', status);
 
-        const res = await fetch(`http://localhost:3001/inquiries?${params}`, {
+        const res = await fetch(`${API_URL}/inquiries?${params}`, {
           credentials: 'include',
         });
         if (res.status === 401) {
@@ -101,7 +102,7 @@ export default function InquiryListPage() {
   }, [status, sort, page, router]);
 
   async function handleLogout() {
-    await fetch('http://localhost:3001/auth/logout', {
+    await fetch(`${API_URL}/auth/logout`, {
       method: 'POST',
       credentials: 'include',
     });
@@ -235,5 +236,13 @@ export default function InquiryListPage() {
         )}
       </main>
     </div>
+  );
+}
+
+export default function InquiryListPage() {
+  return (
+    <Suspense fallback={<p className="text-sm text-gray-500 p-6">読み込み中...</p>}>
+      <InquiryListContent />
+    </Suspense>
   );
 }

--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { API_URL } from '@/lib/api';
 
 export default function AdminLoginPage() {
   const router = useRouter();
@@ -25,7 +26,7 @@ export default function AdminLoginPage() {
 
     setLoading(true);
     try {
-      const res = await fetch('http://localhost:3001/auth/login', {
+      const res = await fetch(`${API_URL}/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { API_URL } from '@/lib/api';
 
 interface FormValues {
   name: string;
@@ -62,7 +63,7 @@ export default function InquiryFormPage() {
 
     setLoading(true);
     try {
-      const res = await fetch('http://localhost:3001/inquiries', {
+      const res = await fetch(`${API_URL}/inquiries`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';


### PR DESCRIPTION
## 概要

フロントエンドのコードに \`http://localhost:3001\` がハードコードされており、本番デプロイで API に到達できない問題を修正する。あわせて本番ビルドで発生していた \`useSearchParams\` のプリレンダエラーも修正。

## 変更内容

### API URL の環境変数化

- \`frontend/lib/api.ts\` を新設
  \`\`\`typescript
  export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
  \`\`\`
- 7 箇所の \`fetch('http://localhost:3001/...')\` を \`fetch(\`\${API_URL}/...\`)\` に変更

### ビルドエラー修正

\`/admin/inquiries\` の \`useSearchParams\` を \`<Suspense>\` でラップ。Next.js のドキュメントに従い、コンポーネントを分割して Suspense 境界を設置。

## 動作確認

- ローカル \`npm run build\` 成功
- 影響ファイル: page.tsx / login/page.tsx / inquiries/page.tsx / inquiries/[id]/page.tsx + lib/api.ts

Closes #41